### PR TITLE
Chat Trigger & Memory Leak Fix

### DIFF
--- a/addons/sourcemod/scripting/abner_killfeed_filter.sp
+++ b/addons/sourcemod/scripting/abner_killfeed_filter.sp
@@ -25,7 +25,7 @@ public void OnPluginStart()
 	g_Victim = CreateConVar("abner_killfeed_filter_victim", "1", "Show Feed to Dead Player");
 	g_Assister = CreateConVar("abner_killfeed_filter_assister", "1", "Show Feed to Assister Player");
 	
-	RegConsoleCmd("sm_killfeed", MenuCookie);
+	RegConsoleCmd("killfeed", MenuCookie);
 	
 	
 	CreateConVar("abner_killfeed_filter_version", PLUGIN_VERSION, "Plugin Version", FCVAR_NOTIFY|FCVAR_REPLICATED);

--- a/addons/sourcemod/scripting/abner_killfeed_filter.sp
+++ b/addons/sourcemod/scripting/abner_killfeed_filter.sp
@@ -3,7 +3,7 @@
 #include <sdkhooks>
 #include <clientprefs>
 
-#define PLUGIN_VERSION "1.4"
+#define PLUGIN_VERSION "1.5"
 
 Handle g_Enabled;
 Handle g_Assister;

--- a/addons/sourcemod/scripting/abner_killfeed_filter.sp
+++ b/addons/sourcemod/scripting/abner_killfeed_filter.sp
@@ -10,7 +10,6 @@ Handle g_Assister;
 Handle g_Victim;
 Handle g_Cookie;
 
-
 public Plugin myinfo =
 {
 	name 			= "AbNeR Kill Feed Filter",
@@ -77,7 +76,6 @@ int GetIntCookie(int client, Handle handle)
 	return StringToInt(sCookieValue);
 }
 
-
 public int MenuHandler(Handle menu, MenuAction action, int param1, int param2)
 {
 	if(param2 == MenuCancel_ExitBack)
@@ -96,10 +94,12 @@ public int MenuHandler(Handle menu, MenuAction action, int param1, int param2)
 		}
 		MenuCookie(param1, 0);
 	}
+	else if (action == MenuAction_End)
+	{
+		delete menu;
+	}
 	return 0;
 }
-
-
 
 public Action OnPlayerDeath(Event ev, char [] name, bool dontBroadcast)
 {

--- a/addons/sourcemod/scripting/abner_killfeed_filter.sp
+++ b/addons/sourcemod/scripting/abner_killfeed_filter.sp
@@ -26,7 +26,7 @@ public void OnPluginStart()
 	g_Victim = CreateConVar("abner_killfeed_filter_victim", "1", "Show Feed to Dead Player");
 	g_Assister = CreateConVar("abner_killfeed_filter_assister", "1", "Show Feed to Assister Player");
 	
-	RegConsoleCmd("killfeed", MenuCookie);
+	RegConsoleCmd("sm_killfeed", MenuCookie);
 	
 	
 	CreateConVar("abner_killfeed_filter_version", PLUGIN_VERSION, "Plugin Version", FCVAR_NOTIFY|FCVAR_REPLICATED);


### PR DESCRIPTION
This PR allows players to use !killfeed or /killfeed in chat, without requiring them to use the console. This also fixes a small memory leak that doesn't properly delete the menu that is created.